### PR TITLE
Add support for two factor authentication

### DIFF
--- a/src/containers/FbContainer.js
+++ b/src/containers/FbContainer.js
@@ -1,5 +1,6 @@
 const util = require('util')
 const async = require('async')
+const readline = require('readline')
 const fblogin = require('facebook-chat-api')
 const debug = require('debug')('botium-FbContainer')
 const debugApi = require('debug')('botium-FbContainer-Api')
@@ -30,7 +31,17 @@ module.exports = class FbContainer extends BaseContainer {
           debug(`logging into facebook page ${this.caps[Capabilities.FB_PAGEID]} with user ${this.caps[Capabilities.FB_USER]}`)
           fblogin({ email: this.caps[Capabilities.FB_USER], password: this.caps[Capabilities.FB_PASSWORD] }, { logLevel: debugApi.enabled ? 'verbose' : 'warn' }, (err, api) => {
             if (err) {
-              fbLoginReady(`Facebook login failed: ${util.inspect(err)}`)
+              if (err.error === 'login-approval') {
+                 var rl = readline.createInterface({
+                   input: process.stdin,
+                   output: process.stdout,
+                 })
+                 rl.question('Please enter two-factor authentication code or authorise login from another browser: ', (answer) => {
+                   err.continue(answer)
+                 })
+              } else {
+                fbLoginReady(`Facebook login failed: ${util.inspect(err)}`)
+              }
             } else {
               debug('logging into facebook ready')
               this.fbapi = api


### PR DESCRIPTION
Add logic to handle Facebook users who have login approval turned on. Users will be prompted to insert a 2 factor authentication code, or to approve the login from another facebook instance (in which case, sending an empty code is sufficient)