### PR TITLE
BOT-230: added pause logic also to convoBegin, convoEnd and onBotStart

### DIFF
--- a/src/scripting/logichook/LogicHookUtils.js
+++ b/src/scripting/logichook/LogicHookUtils.js
@@ -4,6 +4,7 @@ const isClass = require('is-class')
 const debug = require('debug')('botium-asserterUtils')
 const ButtonsAsserter = require('./asserter/ButtonsAsserter')
 const MediaAsserter = require('./asserter/MediaAsserter')
+const PauseAsserter = require('./asserter/PauseAsserter')
 const PauseLogicHook = require('./PauseLogicHook')
 const WaitForBotLogicHook = require('./WaitForBotLogicHook')
 const Capabilities = require('../../Capabilities')
@@ -26,6 +27,7 @@ module.exports = class LogicHookUtils {
   _setDefaultAsserters () {
     this.asserters['BUTTONS'] = new ButtonsAsserter(this.buildScriptContext, this.caps)
     this.asserters['MEDIA'] = new MediaAsserter(this.buildScriptContext, this.caps)
+    this.asserters['PAUSE_ASSERTER'] = new PauseAsserter(this.buildScriptContext, this.caps)
     debug(`Loaded Default asserter - ${util.inspect(Object.keys(this.asserters))}`)
   }
 

--- a/src/scripting/logichook/PauseLogic.js
+++ b/src/scripting/logichook/PauseLogic.js
@@ -1,0 +1,15 @@
+exports.pause = (ref, args) => {
+  if (!args || args.length < 1) {
+    return Promise.reject(new Error(`${ref}: PauseLogicHook Missing argument`))
+  }
+  if (args.length > 1) {
+    return Promise.reject(new Error(`${ref}: PauseLogicHook Too much argument "${args}"`))
+  }
+
+  const parsed = Number(args[0])
+  if (parseInt(parsed, 10) !== parsed) {
+    return Promise.reject(new Error(`${ref}: PauseLogicHook Wrong argument "${args[0]}"`))
+  }
+
+  return new Promise(resolve => setTimeout(resolve, parsed))
+}

--- a/src/scripting/logichook/PauseLogicHook.js
+++ b/src/scripting/logichook/PauseLogicHook.js
@@ -1,3 +1,4 @@
+const pause = require('./PauseLogic').pause
 module.exports = class PauseLogicHook {
   constructor (context, caps = {}) {
     this.context = context
@@ -5,18 +6,10 @@ module.exports = class PauseLogicHook {
   }
 
   onMeStart ({convo, convoStep, args}) {
-    if (!args || args.length < 1) {
-      return Promise.reject(new Error(`${convoStep.stepTag}: PauseLogicHook Missing argument`))
-    }
-    if (args.length > 1) {
-      return Promise.reject(new Error(`${convoStep.stepTag}: PauseLogicHook Too much argument "${args}"`))
-    }
+    return pause(convoStep.stepTag, args)
+  }
 
-    const parsed = Number(args[0])
-    if (parseInt(parsed, 10) !== parsed) {
-      return Promise.reject(new Error(`${convoStep.stepTag}: PauseLogicHook Wrong argument "${args[0]}"`))
-    }
-
-    return new Promise(resolve => setTimeout(resolve, parsed))
+  onBotStart ({convoStep, container, args}) {
+    return pause(convoStep.stepTag, args)
   }
 }

--- a/src/scripting/logichook/asserter/PauseAsserter.js
+++ b/src/scripting/logichook/asserter/PauseAsserter.js
@@ -1,0 +1,16 @@
+const pause = require('../PauseLogic').pause
+
+module.exports = class PauseAsserter {
+  constructor (context, caps = {}) {
+    this.context = context
+    this.caps = caps
+  }
+
+  assertConvoBegin ({convo, container, args}) {
+    return pause(convo.sourceTag, args)
+  }
+
+  assertConvoEnd ({convo, container, msgs, args}) {
+    return pause(convo.sourceTag, args)
+  }
+}

--- a/test/scripting/logichooks/convos/pauseLogic.spec.js
+++ b/test/scripting/logichooks/convos/pauseLogic.spec.js
@@ -1,0 +1,47 @@
+const assert = require('chai').assert
+const PauseLogic = require('../../../../src/scripting/logichook/PauseLogic')
+
+describe('PauseLogic.pause', function () {
+  it('positive case for pause logic', async function () {
+    const pause = PauseLogic.pause
+    const currentDate = new Date()
+    return pause('test', ['1000'])
+      .then(resolve => {
+        const finishedDate = new Date()
+        assert.equal(currentDate.getSeconds() + 1, finishedDate.getSeconds())
+      })
+  })
+  it('negative case for pause logic', async function () {
+    const pause = PauseLogic.pause
+    const currentDate = new Date()
+    return pause('test', ['500'])
+      .then(resolve => {
+        const finishedDate = new Date()
+        assert.notEqual(currentDate.getSeconds() + 2, finishedDate.getSeconds())
+      })
+  })
+  it('wrong number of args', async function () {
+    const pause = PauseLogic.pause
+    return pause('test', ['500', '300'])
+      .catch((err) => {
+        assert.isDefined(err)
+        assert.instanceOf(err, Error)
+      })
+  })
+  it('not a number as argument', async function () {
+    const pause = PauseLogic.pause
+    return pause('test', ['a500'])
+      .catch((err) => {
+        assert.isDefined(err)
+        assert.instanceOf(err, Error)
+      })
+  })
+  it('empty argument list', async function () {
+    const pause = PauseLogic.pause
+    return pause('test', [])
+      .catch((err) => {
+        assert.isDefined(err)
+        assert.instanceOf(err, Error)
+      })
+  })
+})


### PR DESCRIPTION
__Pull Request addresses Issue/Bug:__

What issue/bug is addressed by this pull request ?
add pause logic also to convoBegin convoEnd and onBotStart
__Implemented behaviour:__

What did you actually change ?
extracted pauselogic into to separate file, created PauseAsserter and wrote unit tests for pause logic 

__Build successful?__
yes
Is build still possible ? ("npm run build")
executed and Okay
__Unit Tests changed/added:__
5 Unit test for the logic of pause

Have unit tests been changed or added to reflect new functionality ?
yes