### PR TITLE
Apply scripting memory to utterances

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "botium-core",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botium-core",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "The Selenium for Chatbots",
   "main": "index.js",
   "module": "dist/botium-es.js",

--- a/src/scripting/Convo.js
+++ b/src/scripting/Convo.js
@@ -74,8 +74,9 @@ class Transcript {
 }
 
 class TranscriptStep {
-  constructor ({ expected, actual, stepBegin, stepEnd, botBegin, botEnd, err }) {
+  constructor ({ expected, not, actual, stepBegin, stepEnd, botBegin, botEnd, err }) {
     this.expected = expected
+    this.not = not
     this.actual = actual
     this.stepBegin = stepBegin
     this.stepEnd = stepEnd
@@ -178,6 +179,7 @@ class Convo {
       (convoStep, convoStepDoneCb) => {
         const transcriptStep = new TranscriptStep({
           expected: new BotiumMockMessage(convoStep),
+          not: convoStep.not,
           actual: null,
           stepBegin: new Date(),
           stepEnd: null,

--- a/src/scripting/ScriptingProvider.js
+++ b/src/scripting/ScriptingProvider.js
@@ -53,13 +53,16 @@ module.exports = class ScriptingProvider {
       assertConvoEnd: ({convo, convoStep, ...rest}) => {
         return this._createAsserterPromises((convo.endAsserter || []), convoStep, rest, convo, 'assertConvoEnd')
       },
+      resolveUtterance: ({ utterance }) => {
+        if (this.utterances[utterance]) {
+          return this.utterances[utterance].utterances
+        } else {
+          return [utterance]
+        }
+      },
       assertBotResponse: (botresponse, tomatch, stepTag, meMsg) => {
         if (!_.isArray(tomatch)) {
-          if (this.utterances[tomatch]) {
-            tomatch = this.utterances[tomatch].utterances
-          } else {
-            tomatch = [tomatch]
-          }
+          tomatch = [tomatch]
         }
         debug(`assertBotResponse ${stepTag} ${meMsg ? `(${meMsg}) ` : ''}BOT: ${botresponse} = ${tomatch} ...`)
         const found = _.find(tomatch, (utt) => {
@@ -147,6 +150,7 @@ module.exports = class ScriptingProvider {
         assertConvoBegin: this.scriptingEvents.assertConvoBegin.bind(this),
         assertConvoStep: this.scriptingEvents.assertConvoStep.bind(this),
         assertConvoEnd: this.scriptingEvents.assertConvoEnd.bind(this),
+        resolveUtterance: this.scriptingEvents.resolveUtterance.bind(this),
         assertBotResponse: this.scriptingEvents.assertBotResponse.bind(this),
         assertBotNotResponse: this.scriptingEvents.assertBotNotResponse.bind(this),
         onMeStart: this.scriptingEvents.onMeStart.bind(this),

--- a/test/convo/convos/2stepsneg.convo.txt
+++ b/test/convo/convos/2stepsneg.convo.txt
@@ -1,0 +1,7 @@
+2 steps neg
+
+#me
+Hello
+
+#bot
+!Hugo

--- a/test/convo/convos/memory_fail.convo.txt
+++ b/test/convo/convos/memory_fail.convo.txt
@@ -1,0 +1,14 @@
+scripting memory
+
+#me
+this is a variable: VARVALUE
+
+#bot
+this is a variable: $myvar
+
+#me
+show var $myvar
+
+#bot
+show var VARVALUEINVALID
+

--- a/test/convo/convos/utt_memory.convo.txt
+++ b/test/convo/convos/utt_memory.convo.txt
@@ -1,0 +1,25 @@
+utterances memory
+
+#me
+I am 40 years old
+
+#bot
+AGE_UTT
+
+#me
+show var $years
+
+#bot
+show var 40
+
+#me
+I am 2 months old
+
+#bot
+AGE_UTT
+
+#me
+show var $months
+
+#bot
+show var 2

--- a/test/convo/convos/utt_memory.utterances.txt
+++ b/test/convo/convos/utt_memory.utterances.txt
@@ -1,0 +1,3 @@
+AGE_UTT
+I am $months months old
+I am $years years old

--- a/test/convo/scriptingmemory.spec.js
+++ b/test/convo/scriptingmemory.spec.js
@@ -2,6 +2,9 @@ const path = require('path')
 const assert = require('chai').assert
 const BotDriver = require('../../').BotDriver
 const Capabilities = require('../../').Capabilities
+const ScriptingProvider = require('../../src/scripting/ScriptingProvider')
+const { Convo } = require('../../src/scripting/Convo')
+const DefaultCapabilities = require('../../src/Defaults').Capabilities
 
 const echoConnector = ({ queueBotSays }) => {
   return {
@@ -12,25 +15,124 @@ const echoConnector = ({ queueBotSays }) => {
   }
 }
 
-describe('convo.scriptingmemory', function () {
-  it('should fill scripting memory', async function () {
+describe('convo.scriptingmemory.convos', function () {
+  beforeEach(async function () {
     const myCaps = {
       [Capabilities.PROJECTNAME]: 'convo.scriptingmemory',
       [Capabilities.CONTAINERMODE]: echoConnector,
       [Capabilities.SCRIPTING_ENABLE_MEMORY]: true
     }
     const driver = new BotDriver(myCaps)
-    const compiler = driver.BuildCompiler()
-    const container = await driver.Build()
+    this.compiler = driver.BuildCompiler()
+    this.container = await driver.Build()
+  })
+  afterEach(async function () {
+    this.container && await this.container.Clean()
+  })
 
-    compiler.ReadScript(path.resolve(__dirname, 'convos'), 'memory.convo.txt')
-    assert.equal(compiler.convos.length, 1)
+  it('should fill scripting memory from convo file', async function () {
+    this.compiler.ReadScript(path.resolve(__dirname, 'convos'), 'memory.convo.txt')
+    assert.equal(this.compiler.convos.length, 1)
 
-    const transcript = await compiler.convos[0].Run(container)
+    const transcript = await this.compiler.convos[0].Run(this.container)
     assert.isObject(transcript.scriptingMemory)
     assert.isDefined(transcript.scriptingMemory['$myvar'])
     assert.equal(transcript.scriptingMemory['$myvar'], 'VARVALUE')
+  })
+  it('should fill scripting memory from utterances file', async function () {
+    this.compiler.ReadScript(path.resolve(__dirname, 'convos'), 'utt_memory.convo.txt')
+    assert.equal(this.compiler.convos.length, 1)
+    this.compiler.ReadScript(path.resolve(__dirname, 'convos'), 'utt_memory.utterances.txt')
+    assert.isDefined(this.compiler.utterances['AGE_UTT'])
 
-    await container.Clean()
+    const transcript = await this.compiler.convos[0].Run(this.container)
+    assert.isObject(transcript.scriptingMemory)
+    assert.equal(transcript.scriptingMemory['$years'], '40')
+    assert.equal(transcript.scriptingMemory['$months'], '2')
+  })
+  it('should fail on invalid scripting memory', async function () {
+    this.compiler.ReadScript(path.resolve(__dirname, 'convos'), 'memory_fail.convo.txt')
+    assert.equal(this.compiler.convos.length, 1)
+
+    try {
+      await this.compiler.convos[0].Run(this.container)
+      assert.fail('expected convo to fail')
+    } catch (err) {
+      assert.isTrue(err.message.indexOf('Expected bot response (on Line 12: #me - show var VARVALUE  ) "show var VARVALUE" to match one of "show var VARVALUEINVALID"') > 0)
+    }
+  })
+})
+
+describe('convo.scriptingMemory.api', function () {
+  beforeEach(async function () {
+    this.containerStub = {
+      caps: {
+        [Capabilities.SCRIPTING_ENABLE_MEMORY]: true
+      }
+    }
+    this.scriptingProvider = new ScriptingProvider(DefaultCapabilities)
+    await this.scriptingProvider.Build()
+    this.scriptingContext = this.scriptingProvider._buildScriptContext()
+    this.convo = new Convo(this.scriptingContext, {
+      header: 'test convo',
+      conversation: []
+    })
+    this.scriptingProvider.AddConvos(this.convo)
+  })
+
+  it('should fill scripting memory from text', async function () {
+    const scriptingMemory = {}
+    this.convo._fillScriptingMemory(this.containerStub, scriptingMemory, 'test sentence 1', 'test sentence $num')
+    assert.equal(scriptingMemory['$num'], '1')
+  })
+  it('should not fill scripting memory from invalid text', async function () {
+    const scriptingMemory = {}
+    this.convo._fillScriptingMemory(this.containerStub, scriptingMemory, 'test sentence', 'test sentence $num')
+    assert.isUndefined(scriptingMemory['$num'])
+  })
+  it('should fill scripting memory from one utterance', async function () {
+    this.scriptingProvider.AddUtterances({
+      name: 'utt1',
+      utterances: ['test sentence $num']
+    })
+
+    const scriptingMemory = {}
+    this.convo._fillScriptingMemory(this.containerStub, scriptingMemory, 'test sentence 1', 'utt1')
+    assert.equal(scriptingMemory['$num'], '1')
+  })
+  it('should fill multiple scripting memory from one utterance', async function () {
+    this.scriptingProvider.AddUtterances({
+      name: 'utt1',
+      utterances: ['test sentence $num1 $num2']
+    })
+
+    const scriptingMemory = {}
+    this.convo._fillScriptingMemory(this.containerStub, scriptingMemory, 'test sentence 1 2', 'utt1')
+    assert.equal(scriptingMemory['$num1'], '1')
+    assert.equal(scriptingMemory['$num2'], '2')
+  })
+  it('should fill scripting memory from two different utterances', async function () {
+    this.scriptingProvider.AddUtterances({
+      name: 'utt1',
+      utterances: ['i am $months months old', 'i am $years years old']
+    })
+
+    const scriptingMemory = {}
+    this.convo._fillScriptingMemory(this.containerStub, scriptingMemory, 'i am 2 months old', 'utt1')
+    assert.equal(scriptingMemory['$months'], '2')
+    assert.isUndefined(scriptingMemory['$years'])
+  })
+  it('should replace utterances from scripting memory', async function () {
+    this.scriptingProvider.AddUtterances({
+      name: 'utt1',
+      utterances: ['i am $months months old', 'i am $years years old']
+    })
+    const scriptingMemory = {}
+    this.convo._fillScriptingMemory(this.containerStub, scriptingMemory, 'i am 2 months old', 'utt1')
+
+    const tomatch = this.convo._resolveUtterancesToMatch(this.containerStub, scriptingMemory, 'utt1')
+    assert.isArray(tomatch)
+    assert.equal(tomatch[0], 'i am 2 months old')
+    assert.equal(tomatch[1], 'i am $years years old')
   })
 })

--- a/test/convo/transcript.spec.js
+++ b/test/convo/transcript.spec.js
@@ -45,6 +45,15 @@ describe('convo.transcript', function () {
       assert.isTrue(moment(step.stepBegin).isSameOrBefore(step.stepEnd), 'begin should be same or before end')
     })
   })
+  it('should provide transcript negated steps on success', async function () {
+    this.compiler.ReadScript(path.resolve(__dirname, 'convos'), '2stepsneg.convo.txt')
+    assert.equal(this.compiler.convos.length, 1)
+
+    const transcript = await this.compiler.convos[0].Run(this.container)
+    assert.isDefined(transcript)
+    assert.equal(transcript.steps.length, 2)
+    assert.isTrue(transcript.steps[1].not)
+  })
   it('should include pause in transcript steps', async function () {
     this.compiler.ReadScript(path.resolve(__dirname, 'convos'), '2stepsWithPause.convo.txt')
     assert.equal(this.compiler.convos.length, 1)

--- a/test/scripting/scriptingProvider.spec.js
+++ b/test/scripting/scriptingProvider.spec.js
@@ -1,5 +1,60 @@
 const assert = require('chai').assert
 const ScriptingProvider = require('../../src/scripting/ScriptingProvider')
+const DefaultCapabilities = require('../../src/Defaults').Capabilities
+
+describe('scriptingProvider._resolveUtterances', function () {
+  it('should resolve utterance', async function () {
+    const scriptingProvider = new ScriptingProvider(DefaultCapabilities)
+    await scriptingProvider.Build()
+    const scriptingContext = scriptingProvider._buildScriptContext()
+    scriptingProvider.AddUtterances({
+      name: 'utt1',
+      utterances: ['TEXT1', 'TEXT2']
+    })
+
+    const tomatch = scriptingContext.scriptingEvents.resolveUtterance({ utterance: 'utt1' })
+    assert.isArray(tomatch)
+    assert.equal(tomatch.length, 2)
+    assert.equal(tomatch[0], 'TEXT1')
+    assert.equal(tomatch[1], 'TEXT2')
+    scriptingContext.scriptingEvents.assertBotResponse('TEXT1', tomatch, 'test1')
+  })
+  it('should fail on invalid utterance', async function () {
+    const scriptingProvider = new ScriptingProvider(DefaultCapabilities)
+    await scriptingProvider.Build()
+    const scriptingContext = scriptingProvider._buildScriptContext()
+    scriptingProvider.AddUtterances({
+      name: 'utt1',
+      utterances: ['TEXT1', 'TEXT2']
+    })
+
+    const tomatch = scriptingContext.scriptingEvents.resolveUtterance({ utterance: 'utt2' })
+    assert.isArray(tomatch)
+    assert.equal(tomatch.length, 1)
+    assert.equal(tomatch[0], 'utt2')
+    try {
+      scriptingContext.scriptingEvents.assertBotResponse('TEXT1', tomatch, 'test1')
+      assert.fail('expected error')
+    } catch (err) {
+      assert.isTrue(err.message.indexOf('Expected bot response') > 0)
+    }
+  })
+  it('should fail on unresolved utterance', async function () {
+    const scriptingProvider = new ScriptingProvider(DefaultCapabilities)
+    await scriptingProvider.Build()
+    const scriptingContext = scriptingProvider._buildScriptContext()
+    scriptingProvider.AddUtterances({
+      name: 'utt1',
+      utterances: ['TEXT1', 'TEXT2']
+    })
+    try {
+      scriptingContext.scriptingEvents.assertBotResponse('TEXT1', 'utt1', 'test1')
+      assert.fail('expected error')
+    } catch (err) {
+      assert.isTrue(err.message.indexOf('Expected bot response') > 0)
+    }
+  })
+})
 
 describe('scriptingProvider._isValidAsserterType', function () {
   it('valid asserterType', async function () {


### PR DESCRIPTION
__Pull Request addresses Issue/Bug:__

Scripting Memory should be applied to utterances list

__Implemented behaviour:__

Refactoring of ScriptingProvider.js and Convo.js to apply the memory before doing comparisions

__Build successful?__

yes

__Unit Tests changed/added:__

yes
