### PR TITLE
feature/BOT-675-core-add-structured-error-messages

### DIFF
--- a/src/scripting/BotiumError.js
+++ b/src/scripting/BotiumError.js
@@ -1,0 +1,13 @@
+module.exports = class BotiumError extends Error {
+  constructor (message, context) {
+    super(message)
+
+    // Saving class name in the property of our custom error as a shortcut.
+    this.name = this.constructor.name
+
+    // Capturing stack trace, excluding constructor call from it.
+    Error.captureStackTrace(this, this.constructor)
+
+    this.context = context
+  }
+}

--- a/src/scripting/ScriptingProvider.js
+++ b/src/scripting/ScriptingProvider.js
@@ -10,6 +10,7 @@ const Constants = require('./Constants')
 const Capabilities = require('../Capabilities')
 const { Convo } = require('./Convo')
 const ScriptingMemory = require('./ScriptingMemory')
+const BotiumError = require('./BotiumError')
 const globPattern = '**/+(*.convo.txt|*.utterances.txt|*.pconvo.txt|*.scriptingmemory.txt|*.xlsx|*.convo.csv|*.pconvo.csv)'
 
 const p = (fn) => new Promise((resolve, reject) => {
@@ -86,7 +87,20 @@ module.exports = class ScriptingProvider {
           }
         })
         if (found === undefined) {
-          throw new Error(`${stepTag}: Expected bot response ${meMsg ? `(on ${meMsg}) ` : ''}"${botresponse}" to match one of "${tomatch}"`)
+          throw new BotiumError(`${stepTag}: Expected bot response ${meMsg ? `(on ${meMsg}) ` : ''}"${botresponse}" to match one of "${tomatch}"`,
+            {
+              type: 'response not match',
+              source: 'ScriptingProvider',
+              context: {
+                stepTag
+              },
+              cause: {
+                tomatch,
+                botresponse,
+                meMsg
+              }
+            }
+          )
         }
       },
       assertBotNotResponse: (botresponse, nottomatch, stepTag, meMsg) => {

--- a/src/scripting/logichook/asserter/ButtonsAsserter.js
+++ b/src/scripting/logichook/asserter/ButtonsAsserter.js
@@ -23,7 +23,7 @@ module.exports = class ButtonsAsserter {
           `${convoStep.stepTag}: Expected buttons with text "${buttonsNotFound}"`,
           {
             type: 'asserter',
-            source: 'BottonsAsserter',
+            source: 'ButtonsAsserter',
             params: {
               args,
               botMsg

--- a/src/scripting/logichook/asserter/ButtonsAsserter.js
+++ b/src/scripting/logichook/asserter/ButtonsAsserter.js
@@ -1,3 +1,5 @@
+const BotiumError = require('../../BotiumError')
+
 module.exports = class ButtonsAsserter {
   constructor (context, caps = {}) {
     this.context = context
@@ -16,7 +18,22 @@ module.exports = class ButtonsAsserter {
         }
         buttonsNotFound.push(args[i])
       }
-      if (buttonsNotFound.length > 0) return Promise.reject(new Error(`${convoStep.stepTag}: Expected buttons with text "${buttonsNotFound}"`))
+      if (buttonsNotFound.length > 0) {
+        return Promise.reject(new BotiumError(
+          `${convoStep.stepTag}: Expected buttons with text "${buttonsNotFound}"`,
+          {
+            type: 'asserter',
+            source: 'BottonsAsserter',
+            params: {
+              args,
+              botMsg
+            },
+            cause: {
+              buttonsNotFound
+            }
+          }
+        ))
+      }
     }
     return Promise.resolve()
   }

--- a/src/scripting/logichook/asserter/EntitiesAsserter.js
+++ b/src/scripting/logichook/asserter/EntitiesAsserter.js
@@ -1,5 +1,6 @@
 const _ = require('lodash')
 const util = require('util')
+const BotiumError = require('../../BotiumError')
 
 module.exports = class EntitiesAsserter {
   constructor (context, caps = {}) {
@@ -33,7 +34,29 @@ module.exports = class EntitiesAsserter {
         return 0
       }
     )
-    return Promise.reject(new Error(`${convoStep.stepTag}: Wrong number of entities. The difference is ${util.inspect(substractedAsArray)}`))
+    return Promise.reject(new BotiumError(
+      `${convoStep.stepTag}: Wrong number of entities. The difference is ${util.inspect(substractedAsArray)}`,
+      {
+        type: 'asserter',
+        source: 'EntitiesAsserter',
+        context: {
+          constructor: {
+          },
+          params: {
+            args,
+            botMsg
+          },
+          calculation: {
+            acceptMoreEntities,
+            currentEntities,
+            expectedEntities
+          }
+        },
+        cause: {
+          substractedAsArray
+        }
+      }
+    ))
   }
 }
 

--- a/src/scripting/logichook/asserter/EntityValuesAsserter.js
+++ b/src/scripting/logichook/asserter/EntityValuesAsserter.js
@@ -1,5 +1,6 @@
 const _ = require('lodash')
 const util = require('util')
+const BotiumError = require('../../BotiumError')
 
 module.exports = class EntityValuesAsserter {
   constructor (context, caps = {}) {
@@ -33,7 +34,30 @@ module.exports = class EntityValuesAsserter {
         return 0
       }
     )
-    return Promise.reject(new Error(`${convoStep.stepTag}: Wrong number of entity values. The difference is ${util.inspect(substractedAsArray)}`))
+    return Promise.reject(new BotiumError(
+      `${convoStep.stepTag}: Wrong number of entity values. The difference is ${util.inspect(substractedAsArray)}`,
+      {
+        type: 'asserter',
+        source: 'EntityValuesAsserter',
+        context: {
+          constructor: {
+          },
+          params: {
+            args,
+            botMsg
+          },
+          // intermediate? State?
+          calculation: {
+            acceptMoreEntities,
+            currentEntities,
+            expectedEntities
+          }
+        },
+        cause: {
+          substractedAsArray
+        }
+      }
+    ))
   }
 }
 

--- a/src/scripting/logichook/asserter/IntentAsserter.js
+++ b/src/scripting/logichook/asserter/IntentAsserter.js
@@ -1,4 +1,5 @@
 const _ = require('lodash')
+const BotiumError = require('../../BotiumError')
 
 module.exports = class IntentAsserter {
   constructor (context, caps = {}) {
@@ -8,19 +9,53 @@ module.exports = class IntentAsserter {
 
   assertConvoStep ({ convo, convoStep, args, botMsg }) {
     if (!args || args.length < 1) {
-      return Promise.reject(new Error(`${convoStep.stepTag}: IntentAsserter Missing argument`))
+      return Promise.reject(new BotiumError(`${convoStep.stepTag}: IntentAsserter Missing argument`),
+        {
+          type: 'asserter',
+          subtype: 'wrong parameters',
+          source: 'IntentAsserter',
+          cause: { args }
+        }
+      )
     }
     if (args.length > 1) {
-      return Promise.reject(new Error(`${convoStep.stepTag}: IntentAsserter Too much argument "${args}"`))
+      return Promise.reject(new BotiumError(`${convoStep.stepTag}: IntentAsserter Too much argument "${args}"`),
+        {
+          type: 'asserter',
+          subtype: 'wrong parameters',
+          source: 'IntentAsserter',
+          cause: { args }
+        }
+      )
     }
 
     if (!_.has(botMsg, 'nlp.intent.name')) {
-      return Promise.reject(new Error(`${convoStep.stepTag}: Expected intent "${args[0]}" but found nothing`))
+      return Promise.reject(new BotiumError(`${convoStep.stepTag}: Expected intent "${args[0]}" but found nothing`),
+        {
+          type: 'asserter',
+          subtype: 'wrong parameters',
+          source: 'IntentAsserter',
+          cause: { args, botMsg }
+        }
+      )
     }
 
     const intent = botMsg.nlp.intent.name
     if (intent !== args[0]) {
-      return Promise.reject(new Error(`${convoStep.stepTag}: Expected intent "${args[0]}" but found ${intent}`))
+      return Promise.reject(new BotiumError(`${convoStep.stepTag}: Expected intent "${args[0]}" but found ${intent}`),
+        {
+          type: 'asserter',
+          source: 'IntentAsserter',
+          context: {
+            params: {
+              args,
+              botMsg
+            }
+          },
+          cause: {
+            intent
+          }
+        })
     }
 
     return Promise.resolve()

--- a/src/scripting/logichook/asserter/IntentConfidenceAsserter.js
+++ b/src/scripting/logichook/asserter/IntentConfidenceAsserter.js
@@ -1,4 +1,5 @@
 const _ = require('lodash')
+const BotiumError = require('../../BotiumError')
 
 /**
  * Can be used as local, and as global asserter
@@ -19,36 +20,101 @@ module.exports = class IntentConfidenceAsserter {
 
   assertConvoStep ({ convo, convoStep, args, botMsg, isGlobal }) {
     if (args.length > 1) {
-      return Promise.reject(new Error(`${convoStep.stepTag}: IntentConfidenceAsserter Too much arguments "${args}"`))
+      return Promise.reject(new BotiumError(`${convoStep.stepTag}: IntentConfidenceAsserter Too much arguments "${args}"`),
+        {
+          type: 'asserter',
+          subtype: 'wrong parameters',
+          source: 'IntentConfidenceAsserter',
+          cause: { args }
+        }
+      )
     }
 
     const hasLocalExpectedMinimum = args && args.length
 
     if (!this.hasGlobalExpectedMinimum && !hasLocalExpectedMinimum) {
-      return Promise.reject(new Error(`${convoStep.stepTag}: IntentConfidenceAsserter configured neither global, nor local`))
+      return Promise.reject(new BotiumError(`${convoStep.stepTag}: IntentConfidenceAsserter configured neither global, nor local`),
+        {
+          type: 'asserter',
+          subtype: 'wrong parameters',
+          source: 'IntentConfidenceAsserter',
+          cause: {
+            args,
+            hasGlobalExpectedMinimum: this.hasGlobalExpectedMinimum,
+            hasLocalExpectedMinimum
+          }
+        }
+      )
     }
 
     let expectedMinimum
     if (hasLocalExpectedMinimum) {
       expectedMinimum = Number(args[0])
       if (parseInt(expectedMinimum, 10) !== expectedMinimum) {
-        return Promise.reject(new Error(`${convoStep.stepTag}: IntentConfidenceAsserter Wrong argument. It must be integer "${args[0]}"`))
+        return Promise.reject(new BotiumError(`${convoStep.stepTag}: IntentConfidenceAsserter Wrong argument. It must be integer "${args[0]}"`),
+          {
+            type: 'asserter',
+            subtype: 'wrong parameters',
+            source: 'IntentConfidenceAsserter',
+            cause: {
+              args,
+              expectedMinimum
+            }
+          }
+        )
       }
     } else {
       expectedMinimum = this.globalExpectedMinimum
     }
 
     if (!_.has(botMsg, 'nlp.intent.confidence')) {
-      return Promise.reject(new Error(`${convoStep.stepTag}: Expected confidence minimum "${expectedMinimum}" but found nothing`))
+      return Promise.reject(new BotiumError(`${convoStep.stepTag}: Expected confidence minimum "${expectedMinimum}" but found nothing (botMsg.nlp.intent.confidence is not set)`),
+        {
+          type: 'asserter',
+          subtype: 'wrong parameters',
+          source: 'IntentConfidenceAsserter',
+          cause: {
+            args,
+            botMsg
+          }
+        }
+      )
     }
 
     let confidence = Number(botMsg.nlp.intent.confidence)
     if (Number.isNaN(confidence)) {
-      return Promise.reject(new Error(`${convoStep.stepTag}: Config error. Cant recognize as intent: "${botMsg.nlp.intent.confidence}"`))
+      return Promise.reject(new BotiumError(`${convoStep.stepTag}: Config error. Cant recognize as intent: "${botMsg.nlp.intent.confidence}"`),
+        {
+          type: 'asserter',
+          subtype: 'wrong parameters',
+          source: 'IntentConfidenceAsserter',
+          cause: {
+            args,
+            confidence
+          }
+        }
+      )
     }
 
     if (confidence * 100 < expectedMinimum) {
-      return Promise.reject(new Error(`${convoStep.stepTag}: Confidence expected minimum ${expectedMinimum} current "${confidence * 100}"`))
+      return Promise.reject(new BotiumError(`${convoStep.stepTag}: Confidence expected minimum ${expectedMinimum} current "${confidence * 100}"`,
+        {
+          type: 'asserter',
+          source: 'IntentConfidenceAsserter',
+          context: {
+            constructor: {
+              expectedMinimum: this.globalExpectedMinimum
+            },
+            params: {
+              args,
+              botMsg
+            }
+          },
+          cause: {
+            confidence: confidence * 100
+          }
+        }
+      ))
     }
 
     return Promise.resolve()

--- a/src/scripting/logichook/asserter/MediaAsserter.js
+++ b/src/scripting/logichook/asserter/MediaAsserter.js
@@ -1,3 +1,5 @@
+const BotiumError = require('../../BotiumError')
+
 module.exports = class MediaAsserter {
   constructor (context, caps = {}) {
     this.context = context
@@ -17,7 +19,25 @@ module.exports = class MediaAsserter {
         }
         mediaNotFound.push(args[i])
       }
-      if (mediaNotFound.length > 0) return Promise.reject(new Error(`${convoStep.stepTag}: Expected media with uri "${mediaNotFound}"`))
+      if (mediaNotFound.length > 0) {
+        return Promise.reject(new BotiumError(`${convoStep.stepTag}: Expected media with uri "${mediaNotFound}"`,
+          {
+            type: 'asserter',
+            source: 'IntentConfidenceAsserter',
+            context: {
+              // effective arguments getting from constructor
+              constructor: {},
+              params: {
+                args,
+                botMsg
+              }
+            },
+            cause: {
+              mediaNotFound
+            }
+          }
+        ))
+      }
     }
     return Promise.resolve()
   }

--- a/src/scripting/logichook/asserter/MediaAsserter.js
+++ b/src/scripting/logichook/asserter/MediaAsserter.js
@@ -23,7 +23,7 @@ module.exports = class MediaAsserter {
         return Promise.reject(new BotiumError(`${convoStep.stepTag}: Expected media with uri "${mediaNotFound}"`,
           {
             type: 'asserter',
-            source: 'IntentConfidenceAsserter',
+            source: 'MediaAsserter',
             context: {
               // effective arguments getting from constructor
               constructor: {},


### PR DESCRIPTION
Core-asserters, und matching-check sind fertig. (link-checker zb nicht) Jetzt ist eine rich Error erstellt, aber core verwendet es nur als native error.