### PR TITLE
bugfix/BOT-927-core-jsonpath-asserter-should-ha

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,8 @@ Of course, code contributions are welcome!
 * Please create an issue and refer to it in the pull request
 * Add unit tests for implemented behaviour
 * The NPM script "npm run build" has to succeed before posting a pull request
-** it will run unit tests
-** it will enforce eslint and rollup build
+    * it will run unit tests
+    * it will enforce eslint and rollup build
+* Someone from the core team will review and give feedback within 1-2 days
 
 These points are subject to possible change at any time.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,13 +1,21 @@
+# Thank you!
+First of all, thanks to our awesome community, to all people out there using Botium, catch and document bugs, making improvements, help with documentation and spread the word! Every contribution is meaningful, so thank you for participating. That being said, here are a few guidelines that we ask you to follow so we can successfully address your issue.
+
 # Guidelines for posting issues
 
-* Please review the [Troubleshooting Guide in the Botium Wiki](https://github.com/codeforequity-at/botium-core/wiki/Troubleshooting)
+* Read [How do I get help ?](https://github.com/codeforequity-at/botium-core/issues/180) first
+* Please review the [Troubleshooting Guide in the Botium Wiki](https://botium.atlassian.net/wiki/spaces/BOTIUM/pages/426128/Troubleshooting)
+* The [Botium Wiki](https://botium.atlassian.net/wiki/spaces/BOTIUM/overview) is the first source of information about Botium
 * In case you have some troubles, please __ALWAYS__ attach the debug output from Botium (see "Enable Logging" in the Troubleshooting Guide)
 * Please don't post any secret information (like access keys for Dialogflow or IBM Watson)
 
 # Guidelines for code contributions
 
-Of course, code contributions are welcome!
+Of course, code contributions are welcome! There are many possible ways of extending Botium.
 
+## Contributions to Botium Core
+
+* See some first steps for contributions [in the Botium Wiki](https://botium.atlassian.net/wiki/spaces/BOTIUM/pages/58261505/Contribution+Guide+for+Botium+Core)
 * Please fork the repository
 * Please create an issue and refer to it in the pull request
 * Add unit tests for implemented behaviour
@@ -16,4 +24,16 @@ Of course, code contributions are welcome!
     * it will enforce eslint and rollup build
 * Someone from the core team will review and give feedback within 1-2 days
 
-These points are subject to possible change at any time.
+## Contribute Botium Connectors
+
+* There is a [Developer Guide](https://botium.atlassian.net/wiki/spaces/BOTIUM/pages/38502401/Howto+develop+your+own+Botium+connector) available in the Botium Wiki
+* Tell us about your work! We are happy to include your connector in Botium Core and thank you in our release notes!
+
+## Contribute Botium Asserters
+
+* There is a [Developer Guide](https://botium.atlassian.net/wiki/spaces/BOTIUM/pages/24477705/Developing+Custom+Asserters) available in the Botium Wiki
+* Tell us about your work! We are happy to include your asserter in Botium Core and thank you in our release notes!
+
+
+
+

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ All of the components in the Botium Stack build on top of Botium Core (except Bo
 
 ## News
 
+* __2019/10/13__ We are now at over 35.000 downloads of Botium Core - thanks to our awesome community!
 * __2019/01/20__ Chatbots are driving the industry. With Botium we are driving chatbots. After months of hard work we are finally there: we are proud to announce the __general availability of the newest Botium Stack member, the Botium Box__. Check out some game changing features for testing and training of chatbots with our [Community Edition](https://medium.com/@floriantreml/chatbot-testing-done-right-botium-box-available-now-550e40d3bdd0)!
 
 
@@ -36,3 +37,6 @@ See the [Botium Wiki](https://botium.atlassian.net/wiki/spaces/BOTIUM/overview) 
 Botium Core provides the core functionality. For attaching Botium to your chatbot, there are lots of _connectors_ available for most important chatbot technologies, frameworks, APIs, SDKs, cloud services etc. Please follow these links to the connector repositories. Sample configurations and scripts are included with each connector.
 
 See [here](https://botium.atlassian.net/wiki/spaces/BOTIUM/pages/360553/Botium+Connectors) for the latest connector updates.
+
+## Contributions
+Contributions are welcome! Please read our [Contribution Guide](https://github.com/codeforequity-at/botium-core/blob/master/CONTRIBUTING.md)!

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-# Botium
-The Selenium for Chatbots
+# Botium - The Selenium for Chatbots
 
 [![NPM](https://nodei.co/npm/botium-core.png?downloads=true&downloadRank=true&stars=true)](https://nodei.co/npm/testmybot/)
 

--- a/src/scripting/logichook/asserter/JsonPathAsserter.js
+++ b/src/scripting/logichook/asserter/JsonPathAsserter.js
@@ -61,7 +61,7 @@ module.exports = class JsonPathAsserter {
       const [actual] = jsonPathValues
       const expected = args[1]
 
-      const match = this.context.Match(actual, expected)
+      const match = this.context.Match(String(actual), expected)
 
       if (not && match) {
         return Promise.reject(new BotiumError(`${convoStep.stepTag}: Not expected: ${actual} in jsonPath ${path}"`,
@@ -84,7 +84,7 @@ module.exports = class JsonPathAsserter {
         ))
       }
       if (!not && !match) {
-        return Promise.reject(new BotiumError(`${convoStep.stepTag}: Expected: ${expected} in jsonPath ${path}"`,
+        return Promise.reject(new BotiumError(`${convoStep.stepTag}: Expected: ${expected} in jsonPath ${path}: Actual: ${actual}`,
           {
             type: 'asserter',
             source: this.name,


### PR DESCRIPTION
Two changes proposed:
1) Even though the readme eg. shows that the numeric values can be asserted, it isn't working, hence if we typecast the actual into a string will resolve it.
Eg: While testing the structured content response from Watson if I want to validate the number of options displayed to the user or whether display flag is true/false, we could use something like this :  
JSON_PATH $.output.rich_message.options.length|2
JSON_PATH $..options[0].display|true

2) Added Actual value in the error message thrown, it helps so much with the debugging, especially when the element has been picked up but the actual != expected. 
Eg:  
Failed: 03_welcomeMessageStructuredContent/Line 12: assertion error - Line 12: Expected: 3 in jsonPath $.output.rich_message.options.length Actual: 2

__Pull Request addresses Issue/Bug:__

numeric and boolean JSON path assertion does not work.

__Implemented behaviour:__

Minor changes to help with the assertion of numeric and boolean values.
And debugging.

__Build successful?__

Did not try.

__Unit Tests changed/added:__

Tested the changes on my Project on the latest botium-core
