### PR TITLE
Supply clone of current transcript in calls to setUserInput

### DIFF
--- a/src/scripting/Convo.js
+++ b/src/scripting/Convo.js
@@ -260,7 +260,7 @@ class Convo {
             transcriptStep.actual = meMsg
 
             try {
-              await this.scriptingEvents.setUserInput({ convo: this, convoStep, container, scriptingMemory, meMsg })
+              await this.scriptingEvents.setUserInput({ convo: this, convoStep, container, scriptingMemory, meMsg, transcript: [...transcriptSteps] })
               await this.scriptingEvents.onMeStart({ convo: this, convoStep, container, scriptingMemory, meMsg })
 
               const coreMsg = _.omit(removeBuffers(meMsg), ['sourceData'])


### PR DESCRIPTION
__Pull Request addresses Issue/Bug:__
Addresses the following issue:
https://github.com/codeforequity-at/botium-core/issues/508

__Implemented behaviour:__
Made small changes to Convo.js to provide a cloned copy of current transcript when calling setUserInput

__Build successful?__
Build is successful

__Unit Tests changed/added:__
Could not find any tests directly testing the Convo.js Run method, would need to stub/spy out setUserInput to make sure it is called with the transcript.
