### PR TITLE
BOT-1441-core-incomprehension-utterances - done

### DIFF
--- a/src/scripting/ScriptingProvider.js
+++ b/src/scripting/ScriptingProvider.js
@@ -129,13 +129,13 @@ module.exports = class ScriptingProvider {
         }
         debug(`assertBotResponse ${stepTag} ${meMsg ? `(${meMsg}) ` : ''}BOT: ${botresponse} = ${tomatch} ...`)
         const found = _.find(tomatch, (utt) => this.matchFn(botresponse, utt))
-        if (found === undefined) {
+        if (_.isNil(found)) {
           let message = `${stepTag}: Bot response `
           message += meMsg ? `(on ${meMsg}) ` : ''
           message += botresponse ? ('"' + botresponse + '"') : '<no response>'
           message += ' expected to match '
           message += tomatch && tomatch.length > 1 ? 'one of ' : ''
-          message += `"${tomatch}"`
+          message += `${tomatch.map(e => e ? '"' + e + '"' : '<any response>').join(', ')}`
           throw new BotiumError(
             message,
             {
@@ -158,9 +158,15 @@ module.exports = class ScriptingProvider {
         }
         debug(`assertBotNotResponse ${stepTag} ${meMsg ? `(${meMsg}) ` : ''}BOT: ${botresponse} != ${nottomatch} ...`)
         const found = _.find(nottomatch, (utt) => this.matchFn(botresponse, utt))
-        if (found) {
+        if (!_.isNil(found)) {
+          let message = `${stepTag}: Bot response `
+          message += meMsg ? `(on ${meMsg}) ` : ''
+          message += botresponse ? ('"' + botresponse + '"') : '<no response>'
+          message += ' expected NOT to match '
+          message += nottomatch && nottomatch.length > 1 ? 'one of ' : ''
+          message += `${nottomatch.map(e => e ? '"' + e + '"' : '<any response>').join(', ')}`
           throw new BotiumError(
-            `${stepTag}: Expected bot response ${meMsg ? `(on ${meMsg}) ` : ''}"${botresponse}" NOT to match "${found}"`,
+            message,
             {
               type: 'asserter',
               source: 'TextMatchAsserter',

--- a/test/scripting/scriptingProvider.spec.js
+++ b/test/scripting/scriptingProvider.spec.js
@@ -454,7 +454,43 @@ describe('scriptingProvider.assertBotResponse', function () {
       scriptingContext.scriptingEvents.assertBotResponse('actual', ['expected1', 'expected2'], 'test1')
       assert.fail('expected error')
     } catch (err) {
-      assert.equal(err.message, 'test1: Bot response "actual" expected to match one of "expected1,expected2"')
+      assert.equal(err.message, 'test1: Bot response "actual" expected to match one of "expected1", "expected2"')
+    }
+  })
+})
+
+describe('scriptingProvider.assertBotNotResponse', function () {
+  it('should fail with correct error message on match', async function () {
+    const scriptingProvider = new ScriptingProvider(DefaultCapabilities)
+    await scriptingProvider.Build()
+    const scriptingContext = scriptingProvider._buildScriptContext()
+    try {
+      scriptingContext.scriptingEvents.assertBotNotResponse('Keine Antwort gefunden!', ['Keine Antwort gefunden'], 'test1')
+      assert.fail('expected error')
+    } catch (err) {
+      assert.equal(err.message, 'test1: Bot response "Keine Antwort gefunden!" expected NOT to match "Keine Antwort gefunden"')
+    }
+  })
+  it('should fail with correct error message on by empty asserter', async function () {
+    const scriptingProvider = new ScriptingProvider(DefaultCapabilities)
+    await scriptingProvider.Build()
+    const scriptingContext = scriptingProvider._buildScriptContext()
+    try {
+      scriptingContext.scriptingEvents.assertBotNotResponse('Keine Antwort gefunden!', [''], 'test1')
+      assert.fail('expected error')
+    } catch (err) {
+      assert.equal(err.message, 'test1: Bot response "Keine Antwort gefunden!" expected NOT to match <any response>')
+    }
+  })
+  it('should fail with correct error message on by empty asserter, and empty bot response', async function () {
+    const scriptingProvider = new ScriptingProvider(DefaultCapabilities)
+    await scriptingProvider.Build()
+    const scriptingContext = scriptingProvider._buildScriptContext()
+    try {
+      scriptingContext.scriptingEvents.assertBotNotResponse('', [''], 'test1')
+      assert.fail('expected error')
+    } catch (err) {
+      assert.equal(err.message, 'test1: Bot response <no response> expected NOT to match <any response>')
     }
   })
 })


### PR DESCRIPTION
`if (found) {`

if found is '' then it was false.