### PR TITLE
BOT-1526 CORE: If SCRIPTING_ENABLE_MULTIPLE_ASSERT_ERRORS is enabled,…

### DIFF
--- a/src/scripting/Convo.js
+++ b/src/scripting/Convo.js
@@ -254,7 +254,7 @@ class Convo {
       }
 
       if (errors.length === 1) {
-        throw new TranscriptError(transcript.err, transcript)
+        throw new TranscriptError(errors[0], transcript)
       } else if (errors.length > 1) {
         throw new TranscriptError(botiumErrorFromList(errors, {}), transcript)
       }


### PR DESCRIPTION
Always run `onConvoEnd` and `assertConvoEnd` after `runConversation` and collect in errors array if something goes wrong. At the end according to the length of errors a `TranscriptError` is thrown. This way all the errors are collected.