### PR TITLE
#621 conversation messages may start with pound sign

### DIFF
--- a/src/scripting/CompilerTxt.js
+++ b/src/scripting/CompilerTxt.js
@@ -89,7 +89,7 @@ module.exports = class CompilerTxt extends CompilerBase {
     lines.forEach((line) => {
       currentLineIndex++
       line = line.trim()
-      if (line && line.startsWith('#')) {
+      if (line && (line.startsWith('#begin') || line.startsWith('#end') || line.startsWith('#me') || line.startsWith('#bot') || line.startsWith('#include'))) {
         pushPrev()
 
         convoStepSender = line.substr(1).trim()


### PR DESCRIPTION
__Pull Request addresses Issue/Bug:__

https://github.com/codeforequity-at/botium-core/issues/621

__Implemented behaviour:__

Parsing line in CompilerText.js

__Build successful?__

I do not have a Node.js build environment
```

sh: eslint: command not found
npm ERR! code 127
npm ERR! path /Users/afreed/Code/workspace-public-ghe/botium-core
npm ERR! command failed
npm ERR! command sh -c eslint "./src/**/*.js" "./test/**/*.js"

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/afreed/.npm/_logs/2021-04-19T14_28_50_607Z-debug.log
npm ERR! code 127
npm ERR! path /Users/afreed/Code/workspace-public-ghe/botium-core
npm ERR! command failed
npm ERR! command sh -c npm run eslint && nyc npm test && nyc check-coverage --lines 50 --functions 50 --branches 35 && rollup -c

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/afreed/.npm/_logs/2021-04-19T14_28_50_649Z-debug.log
```

__Unit Tests changed/added:__

Have unit tests been changed or added to reflect new functionality ?
No, but test conversation is included in original issue.

DCO 1.1 Signed-off-by: Andrew R. Freed <afreed@us.ibm.com>