### PR TITLE
BOT-6417 optional chaining for response headers undefined access

### DIFF
--- a/src/containers/plugins/SimpleRestContainer.js
+++ b/src/containers/plugins/SimpleRestContainer.js
@@ -550,7 +550,8 @@ module.exports = class SimpleRestContainer {
           fetch(requestOptions.uri, requestOptions).then(async (bodyRaw) => {
             let body
             try {
-              if (bodyRaw.headers.get('content-type').includes('application/json')) {
+              const contentType = bodyRaw.headers.get('content-type')
+              if (contentType && contentType.includes('application/json')) {
                 try {
                   body = await bodyRaw.json()
                 } catch (err) {


### PR DESCRIPTION
__Pull Request addresses Issue/Bug:__

when accessing bodyRaw.headers.get('content-type') if the fetch response object is missing the headers property.

__Implemented behaviour:__

Added optional chaining when headers is undefined
__Build successful?__

Yes
__Unit Tests changed/added:__

No